### PR TITLE
Fix RECEIVER_NOT_EXPORTED should be specified

### DIFF
--- a/android/src/main/java/io/blockshake/ledger/operations/RequestPermissionOperation.java
+++ b/android/src/main/java/io/blockshake/ledger/operations/RequestPermissionOperation.java
@@ -42,7 +42,11 @@ public class RequestPermissionOperation extends UsbMethodCallOperation {
             }
         };
 
-        context.registerReceiver(receiver, new IntentFilter(ACTION_USB_PERMISSION));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.registerReceiver(receiver, new IntentFilter(ACTION_USB_PERMISSION), Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            context.registerReceiver(receiver, new IntentFilter(ACTION_USB_PERMISSION));
+        }
 
         usbManager.requestPermission(device, getPendingIntent(context));
     }
@@ -52,7 +56,7 @@ public class RequestPermissionOperation extends UsbMethodCallOperation {
     PendingIntent getPendingIntent(Context context) {
         int flags;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            flags = PendingIntent.FLAG_MUTABLE | PendingIntent.FLAG_UPDATE_CURRENT;
+            flags = PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT;
         } else {
             flags = PendingIntent.FLAG_UPDATE_CURRENT;
         }


### PR DESCRIPTION
This PR fixes an Issue with Android 14 USB

`One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced USB permission request handling with conditional logic based on Android API levels.
	- Improved security by ensuring `PendingIntent` is immutable for devices running Android S (API level 31) or higher.

- **Bug Fixes**
	- Resolved issues related to broadcast receiver registration for USB permissions on different Android versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->